### PR TITLE
#22 Fix FileNotFoundException for removed files

### DIFF
--- a/Solution/WorkingFilesList.ToolWindow/Service/PathCasingRestorer.cs
+++ b/Solution/WorkingFilesList.ToolWindow/Service/PathCasingRestorer.cs
@@ -46,7 +46,12 @@ namespace WorkingFilesList.ToolWindow.Service
 
             var fileInfo = new FileInfo(fullName);
             var parentDirInfo = fileInfo.Directory;
-            var fileName = parentDirInfo.GetFiles(fileInfo.Name)[0].Name;
+            var fileName = fileInfo.Name;
+
+            if (fileInfo.Exists)
+            {
+                fileName = parentDirInfo.GetFiles(fileInfo.Name)[0].Name;
+            }
 
             var returnValue = fileName;
 


### PR DESCRIPTION
The WorkingFileList package failed to load when opening a solution, where a source file in one of the projects had been removed recently.